### PR TITLE
resize and compress images before upload

### DIFF
--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -21,6 +21,9 @@ import {
 } from "../util";
 import { Puzzle } from "../types";
 import uuid from "uuid";
+import * as ImageManipulator from "expo-image-manipulator";
+
+import { DEFAULT_IMAGE_SIZE, COMPRESSION } from "../constants";
 
 export default ({
   navigation,
@@ -102,7 +105,17 @@ export default ({
   };
 
   const uploadImage = async (fileName: string): Promise<void> => {
-    const blob: Blob = await createBlob(imageURI);
+    //resize and compress the image for upload
+    const resizedCompressedImage = await ImageManipulator.manipulateAsync(
+      imageURI,
+      [
+        {
+          resize: DEFAULT_IMAGE_SIZE,
+        },
+      ],
+      { compress: COMPRESSION, format: ImageManipulator.SaveFormat.JPEG }
+    );
+    const blob: Blob = await createBlob(resizedCompressedImage.uri);
     const ref = storage.ref().child(fileName);
     await ref.put(blob);
     return;

--- a/constants.ts
+++ b/constants.ts
@@ -2,4 +2,11 @@ const TESTING_MODE = false;
 
 const SNAP_MARGIN = 0.25;
 
-export { TESTING_MODE, SNAP_MARGIN };
+const COMPRESSION = 0.5;
+
+const DEFAULT_IMAGE_SIZE = {
+  width: 1080,
+  height: 1080,
+};
+
+export { TESTING_MODE, SNAP_MARGIN, COMPRESSION, DEFAULT_IMAGE_SIZE };


### PR DESCRIPTION
title says it all. not much to this. image upload is much faster when not using full resolution and quality of your phone's fancy cam (test images from my phone scaled down from 5-10MB to ~150kb). might solve aspect ratio problems on smaller images, too.