### PR TITLE
bug fix for sent puzzle list link regen

### DIFF
--- a/components/SentPuzzleList.tsx
+++ b/components/SentPuzzleList.tsx
@@ -23,7 +23,7 @@ export default ({
   receivedPuzzles: Puzzle[];
   sentPuzzles: Puzzle[];
   setSentPuzzles: (puzzles: Puzzle[]) => void;
-}) => {
+}): JSX.Element => {
   const [modalVisible, setModalVisible] = React.useState(false);
   const [puzzleToDelete, setPuzzleToDelete] = React.useState<Puzzle | null>(
     null
@@ -36,7 +36,7 @@ export default ({
 
   const sendPuzzle = (publicKey: string | undefined) => {
     const deepLink = Linking.createURL("", {
-      queryParams: { puzzle: publicKey },
+      queryParams: { publicKey },
     });
     shareMessage(deepLink);
   };


### PR DESCRIPTION
Tiny edit to make the sms generated by the sent puzzle list consistent with the one generated when first uploading the puzzle