### PR TITLE
seemingly simple fix

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -67,7 +67,7 @@ const App = () => {
       if (url && initialLoad) fetchPuzzle(url);
     });
     if (!url) getInitialUrl();
-  }, [initialLoad, navigationRef]);
+  }, [initialLoad]);
 
   const fetchPuzzle = async (url: string): Promise<void> => {
     console.log(url);


### PR DESCRIPTION
This is related to something Jeff already commented on:
[https://github.com/FJAM-Studios/pixtery/pull/22/files#r614306087](https://github.com/FJAM-Studios/pixtery/pull/22/files#r614306087)

All I did was remove the navigationRef from the App's useEffect that starts the URL listeners. The reason I thought it was needed is related to this:
[https://reactnavigation.org/docs/navigating-without-navigation-prop/#handling-initialization](https://reactnavigation.org/docs/navigating-without-navigation-prop/#handling-initialization)

But it seems like everything works just as before but now doesn't have the double-listener problem and doesn't have the problem related to adding new puzzles and navigating between them. I don't know if this will cause other problems related to the navigation not being rendered (as that link seems to suggest), but I haven't experienced that so far in testing, and it's certainly an upgrade.