### PR TITLE
Image crops to square when it does not fill the select box

### DIFF
--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -85,6 +85,7 @@ export default ({
         });
 
     if (!result.cancelled) {
+      // if the resulting image is not a square because user did not zoom to fill image select box
       if (result.width !== result.height)
         result.uri = await cropToSquare(result);
       setImageURI(result.uri);
@@ -101,6 +102,8 @@ export default ({
       [
         {
           crop: {
+            // Origin X / Y are upper left coordinates where cropping begins
+            // if width / height is larger than the square length, calculates coordinate (midpoint - half of the square)
             originX:
               width > lengthOfSquare ? width / 2 - lengthOfSquare / 2 : 0,
             originY:


### PR DESCRIPTION
This PR is regarding the issue that I mentioned a few weeks ago, where the recipient was getting a distorted version of what the sender was seeing in their preview (at "Make Puzzle"). I initially thought it was just iOS, but may also be Android (see more below).

After "console.logging" the image at various points, what I got to was that even if Expo ImagePicker is supposed to return a square image for iOS (and for Android because of how we have aspect set up), and even if user sees what looks cropped to a square in the preview box, I think what was happening was that when the image did not fill the square select box, the image did not convert to a square (whereas if you zoom the photo to fill the square, it was fine). (Jeff I think this is what you were mentioning as well previously). See below for what I mean:

![image](https://user-images.githubusercontent.com/59271264/117551197-8445d100-b012-11eb-9f6e-02cc78f752d9.png)

So I added a crop function if the width / height of the image selected are not equal (i.e. not a square), which should crop the image to what the user sees in the preview box, since it looks like the preview box displays a centered square (with square length being the shorter of width/height).

I'd be curious if this was also an Android issue as well, since it seems more to do with Expo not knowing how to make a square out of an image that doesn't fill the select box. 

To test, the best way is probably to try to load a rectangular image, and see if the puzzle that is in your preview box at "Make" is the same after you complete the puzzle.

I also lightly organized the component so that it's state, functions, useEffect. Sorry, I realized after it might be hard to see what I added for the cropping - that is from lines 87-116 ("cropToSquare" function). 