### PR TITLE
check for public key before moving to add puzzle

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,4 @@
 import {
-  CommonActions,
   NavigationContainer,
   NavigationContainerRef,
 } from "@react-navigation/native";
@@ -21,7 +20,7 @@ import SentPuzzleList from "./components/SentPuzzleList";
 import Splash from "./components/Splash";
 import TitleScreen from "./components/TitleScreen";
 import { Puzzle as PuzzleType, Profile as ProfileType } from "./types";
-import { goToScreen } from "./util"
+import { goToScreen } from "./util";
 
 //less than ideal, but idk if we have a choice right now. suppresses the firebase timeout warning
 LogBox.ignoreLogs(["Setting a timer for a long period of time"]);
@@ -66,7 +65,10 @@ const App = (): JSX.Element => {
 
   // to control trigger order and prevent users from skipping the login screen, puzzle querying has been moved to AddPuzzle, which is called from Splash, which is navigated to only after the navigation container loads using the onReady prop
   const gotoSplash = () => {
-    if (navigationRef.current) goToScreen(navigationRef.current, "Splash");
+    // this timeout is if we want to force users to see the starting screen before moving on.
+    setTimeout(() => {
+      if (navigationRef.current) goToScreen(navigationRef.current, "Splash");
+    }, 1000);
   };
 
   return (

--- a/components/AddPuzzle.tsx
+++ b/components/AddPuzzle.tsx
@@ -80,18 +80,16 @@ export default function AddPuzzle({
     const searchForPuzzle = async () => {
       // all logic determining which screen to navigate to happens here in order to place navigation at the end of every branch. Otherwise the function will continue running after navigating away, which can cause the user to get redirected if there is an uncaught navigation further down the line
       try {
-        const { publicKey }: any = Linking.parse(route.params.url).queryParams;
-        if (publicKey) {
-          const match = searchForLocalMatch(publicKey);
-          if (match) goToScreen(navigation, "Puzzle", { publicKey });
-          else {
-            const newPuzzle: Puzzle | void = await fetchPuzzle(publicKey);
-            if (newPuzzle) {
-              await savePuzzle(newPuzzle);
-              goToScreen(navigation, "Puzzle", { publicKey });
-            } else goToScreen(navigation, "Home");
-          }
-        } else goToScreen(navigation, "Home");
+        const { publicKey } = route.params; //no need to check whether publicKey exists, that is done by Splash before navigating here
+        const match = searchForLocalMatch(publicKey);
+        if (match) goToScreen(navigation, "Puzzle", { publicKey });
+        else {
+          const newPuzzle: Puzzle | void = await fetchPuzzle(publicKey);
+          if (newPuzzle) {
+            await savePuzzle(newPuzzle);
+            goToScreen(navigation, "Puzzle", { publicKey });
+          } else goToScreen(navigation, "Home");
+        }
       } catch (e) {
         console.log(e);
       }

--- a/components/Splash.tsx
+++ b/components/Splash.tsx
@@ -67,8 +67,8 @@ export default function Splash({
       //if you are logged in, load local puzzles, then either navigate to AddPuzzle or Home if there is no url
       if (profile) {
         await loadPuzzles();
-        console.log("params", route.params);
-        if (url) goToScreen(navigation, "AddPuzzle", { url });
+        const { publicKey }: any = Linking.parse(url).queryParams;
+        if (publicKey) goToScreen(navigation, "AddPuzzle", { publicKey });
         else goToScreen(navigation, "Home");
       } else {
         //otherwise, load profile from local storage if it exists

--- a/components/TitleScreen.tsx
+++ b/components/TitleScreen.tsx
@@ -2,7 +2,6 @@
 
 import React from "react";
 import { View } from "react-native";
-import { ActivityIndicator } from "react-native-paper";
 
 import Logo from "./Logo";
 import Title from "./Title";
@@ -21,7 +20,6 @@ export default function TiteScreen({ theme }: { theme: any }): JSX.Element {
     >
       <Logo width="100" height="100" />
       <Title width="100" height="35" />
-      <ActivityIndicator animating color={theme.colors.text} size="large" />
     </View>
   );
 }


### PR DESCRIPTION
This fixes the bug that Adam noticed earlier, where add puzzle was showing even when the app wasn't opened with a link. Now splash checks for a publickey not just a url before moving to add puzzle.

And I'm testing adding a timeout so users have to see the title screen when the app initializes. If people don't like it I can take it out.