### PR TITLE
handle error in case of invalid local storage

### DIFF
--- a/components/Puzzle.tsx
+++ b/components/Puzzle.tsx
@@ -124,7 +124,7 @@ export default ({
     const matchingPuzzles = [...receivedPuzzles, ...sentPuzzles].filter(
       (puz) => puz.publicKey === publicKey
     );
-    if (matchingPuzzles.length) {
+    if (matchingPuzzles.length && puzzleAreaDimensions.puzzleAreaWidth > 0) {
       const pickedPuzzle = matchingPuzzles[0];
       const { gridSize, puzzleType, imageURI } = pickedPuzzle;
       const squareSize = boardSize / gridSize;


### PR DESCRIPTION
Small PR for handling the case of a missing local image. Displays an error and navigates back home. I'd imagine this could come up if you somehow delete your images without deleting your puzzle list.

It looks like more in git, but it's just an additional try/catch.