### PR TITLE
ScrollView on PuzzleLists

### DIFF
--- a/components/PuzzleList.tsx
+++ b/components/PuzzleList.tsx
@@ -1,7 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import moment from "moment";
 import * as React from "react";
-import { View, TouchableOpacity } from "react-native";
+import { View, ScrollView, TouchableOpacity } from "react-native";
 import Modal from "react-native-modal";
 import { Text, Card, IconButton, Button, Headline } from "react-native-paper";
 import { Theme } from "react-native-paper/lib/typescript/types";
@@ -102,7 +102,7 @@ export default function PuzzleList({
         }
         navigation={navigation}
       />
-      <View>
+      <ScrollView>
         {receivedPuzzles.map((receivedPuzzle, ix) => (
           <TouchableOpacity
             onPress={() =>
@@ -149,7 +149,7 @@ export default function PuzzleList({
             </Card>
           </TouchableOpacity>
         ))}
-      </View>
+      </ScrollView>
     </AdSafeAreaView>
   );
 }

--- a/components/SentPuzzleList.tsx
+++ b/components/SentPuzzleList.tsx
@@ -2,7 +2,12 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Linking from "expo-linking";
 import moment from "moment";
 import * as React from "react";
-import { ImageBackground, View, TouchableOpacity } from "react-native";
+import {
+  ImageBackground,
+  View,
+  ScrollView,
+  TouchableOpacity,
+} from "react-native";
 import Modal from "react-native-modal";
 import { Card, IconButton, Button, Headline } from "react-native-paper";
 import { Theme } from "react-native-paper/lib/typescript/types";
@@ -114,7 +119,7 @@ export default function SentPuzzleList({
         }
         navigation={navigation}
       />
-      <View>
+      <ScrollView>
         {sentPuzzles.map((sentPuzzle, ix) => (
           <TouchableOpacity
             onPress={() =>
@@ -169,7 +174,7 @@ export default function SentPuzzleList({
             </Card>
           </TouchableOpacity>
         ))}
-      </View>
+      </ScrollView>
     </AdSafeAreaView>
   );
 }


### PR DESCRIPTION
Based on everyone's feedback, both sent and received puzzle lists use ScrollView, which allows users to scroll through a list when the number of puzzles exceed screen length