### PR TITLE
tiny text fix on puzzle 

### DIFF
--- a/components/Puzzle.tsx
+++ b/components/Puzzle.tsx
@@ -290,7 +290,10 @@ export default function PuzzleComponent({
           <View style={styles(styleProps).puzzleArea}>
             <View style={styles(styleProps).messageContainer}>
               <Text style={styles(styleProps).startText}>
-                Drag pieces onto the board! Double tap to rotate!
+                Drag pieces onto the board!
+              </Text>
+              <Text style={styles(styleProps).startText}>
+                Double tap a piece to rotate!
               </Text>
             </View>
           </View>
@@ -333,7 +336,7 @@ export default function PuzzleComponent({
 const styles = (props: { theme: Theme; boardSize: number }) =>
   StyleSheet.create({
     messageContainer: {
-      flexDirection: "row",
+      flexDirection: "column",
       zIndex: -1,
     },
     winContainer: {
@@ -346,12 +349,13 @@ const styles = (props: { theme: Theme; boardSize: number }) =>
       textAlign: "center",
       flex: 1,
       color: "white",
+      marginTop: 20,
     },
     startText: {
       fontSize: 20,
       flexWrap: "wrap",
       textAlign: "center",
-      flex: 1,
+      margin: 10,
       color: "white",
     },
     puzzleArea: {


### PR DESCRIPTION
https://expo.io/@fjam-studios/pixtery?release-channel=text-fix

I just made some small changes on the text on the puzzle component:
1) just to make the instructions clearer on the board, they are now one line per sentence, and adds the word "a piece" to the double tap instructions
2) increased some margin at the top of the win message so it's not flush with the board