### PR TITLE
Updates to Messages

### DIFF
--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -65,10 +65,12 @@ export default function Home({
   const [gridSize, setGridSize] = React.useState(3);
   const [modalVisible, setModalVisible] = React.useState(false);
   const [message, setMessage] = React.useState("");
+  const messageLimit = 70;
   const [paths, setPaths] = React.useState(
     generateJigsawPiecePaths(gridSize, boardSize / (1.6 * gridSize), true)
   );
   const [buttonHeight, setButtonHeight] = React.useState(0);
+  const [textFocus, setTextFocus] = React.useState(false);
 
   const selectImage = async (camera: boolean) => {
     const result = camera
@@ -454,16 +456,25 @@ export default function Home({
           </Surface>
         </View>
         <TextInput
-          placeholder="Message (optional)"
+          placeholder="Message (optional, shows when solved)"
+          multiline={textFocus}
+          maxLength={messageLimit}
           disabled={!imageURI.length}
           mode="outlined"
           value={message}
           onChangeText={(message) => setMessage(message)}
+          onFocus={() => setTextFocus(true)}
+          onBlur={() => setTextFocus(false)}
           style={{
-            height: height * 0.09,
+            minHeight: height * 0.09,
             justifyContent: "center",
           }}
         />
+        {textFocus ? (
+          <Text style={{ textAlign: "right" }}>
+            {message.length}/{messageLimit} characters
+          </Text>
+        ) : null}
         <Button
           icon="send"
           mode="contained"


### PR DESCRIPTION
This PR introduces:

1. A character limit to messages (currently set to 70*) and a character counter that appears when the Text Input area is On Focus
2. Also when the Text Input field is On Focus, it changes to Multiline to support longer messages
3. Small update to placeholder to let user know when message is revealed

*This is totally adjustable. Right now, on my display, up to 24 characters per line can appear, with a maximum of 7 lines before the Ad Banner is reached, for a true max total of 168 characters (though this may change on different displays). However, in the interest of keeping some real estate open to potentially add more to this page later (Title, bigger board, Timer(?)), I'm setting it pretty low at 'half a tweet'