### PR TITLE
fix center piece rotation bug

### DIFF
--- a/puzzleUtils.ts
+++ b/puzzleUtils.ts
@@ -445,11 +445,17 @@ export const validateBoard = (
   gridSize: number
 ): boolean => {
   if (currentBoard.length === gridSize * gridSize) {
+    // set orientation as top left corner piece rotation
+    const orientation = currentBoard.filter(
+      (piece) => piece.pointIndex === 0
+    )[0].rotation;
     for (let i = 0; i < currentBoard.length; i++) {
       const { pointIndex, solvedIndex, rotation } = currentBoard[i];
       if (
         // rotated location of piece must match solution location
-        rotateIndex(pointIndex, gridSize, rotation) !== solvedIndex
+        rotateIndex(pointIndex, gridSize, rotation) !== solvedIndex ||
+        // ensure all pieces oriented same direction
+        orientation !== rotation
       ) {
         return false;
       }


### PR DESCRIPTION
This fixes a bug I found in testing that the puzzle could be solved with the center piece of a 3x3 puzzle rotated the wrong way. This happened because the center piece is in the right spot regardless of which way it is facing. The fix is to make sure all the pieces are facing the same way for a win to be recognized.