### PR TITLE
added try catch

### DIFF
--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -210,8 +210,12 @@ export default function Home({
 
   const displayPainfulAd = async () => {
     if (DISPLAY_PAINFUL_ADS) {
-      await AdMobInterstitial.requestAdAsync();
-      await AdMobInterstitial.showAdAsync();
+      try {
+        await AdMobInterstitial.requestAdAsync();
+        await AdMobInterstitial.showAdAsync();
+      } catch (error) {
+        console.log(error);
+      }
     }
   };
 


### PR DESCRIPTION
This prevents the app from hanging if google doesn't provide any ads to show, which is happening in the standalone ios app. People on the forums have said that it can take a few days after building them to start.