### PR TITLE
fix iOS issue of message text disappearing if user clicks out of box

### DIFF
--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -463,7 +463,7 @@ export default function Home({
         </View>
         <TextInput
           placeholder="Message (optional, shows when solved)"
-          multiline={textFocus}
+          multiline
           maxLength={messageLimit}
           disabled={!imageURI.length}
           mode="outlined"


### PR DESCRIPTION
This addresses a bug that Adam found where on iOS (but not Android), if a user types a message and then clicks out of it, the in progress message disappears from the text box. I think we just need to set multiline to true (vs true/false based on textFocus), this works on my iOS device but let me know if this messes things up on Android.