### PR TITLE
pieces prevented from going below ad

### DIFF
--- a/components/AdSafeAreaView.tsx
+++ b/components/AdSafeAreaView.tsx
@@ -1,5 +1,5 @@
 import { AdMobBanner } from "expo-ads-admob";
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { StyleProp, ViewStyle, View, LayoutChangeEvent } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useDispatch, useSelector } from "react-redux";

--- a/components/Puzzle.tsx
+++ b/components/Puzzle.tsx
@@ -49,6 +49,7 @@ export default function PuzzleComponent({
   );
   const sentPuzzles = useSelector((state: RootState) => state.sentPuzzles);
   const adHeight = useSelector((state: RootState) => state.adHeight);
+  const [lowerBound, setLowerBound] = useState<number>(0);
 
   const [puzzle, setPuzzle] = useState<Puzzle>();
   const [pieces, setPieces] = useState<Piece[]>([]);
@@ -156,6 +157,8 @@ export default function PuzzleComponent({
           squareSize,
         minSandboxY
       );
+
+      setLowerBound(maxSandboxY);
 
       setPuzzle(pickedPuzzle);
 
@@ -322,6 +325,7 @@ export default function PuzzleComponent({
                 snapPoints={snapPoints}
                 currentBoard={currentBoard.current}
                 checkWin={checkWin}
+                lowerBound={lowerBound}
               />
             ))
           ) : (

--- a/components/PuzzlePiece.tsx
+++ b/components/PuzzlePiece.tsx
@@ -27,6 +27,7 @@ export default function PuzzlePiece({
   snapPoints,
   currentBoard,
   checkWin,
+  lowerBound,
 }: {
   piece: Piece;
   puzzleAreaDimensions: { puzzleAreaWidth: number; puzzleAreaHeight: number };
@@ -34,6 +35,7 @@ export default function PuzzlePiece({
   snapPoints: Point[];
   currentBoard: BoardSpace[];
   checkWin: () => void;
+  lowerBound: number;
 }): JSX.Element {
   const {
     pieceDimensions,
@@ -109,10 +111,7 @@ export default function PuzzlePiece({
         lastOffset.x
       );
       lastOffset.y = Math.min(
-        pieceDimensions.height * 0.5 +
-          puzzleAreaDimensions.puzzleAreaHeight -
-          pieceDimensions.height -
-          initialPlacement.y,
+        lowerBound - pieceDimensions.height * 0.5 - initialPlacement.y,
         lastOffset.y
       );
       // snap piece here using lastOffset, adjust for centered snapping points


### PR DESCRIPTION
This uses the updated lower boundary when placing pieces initially to prevent the user from dragging a piece into the ad.