### PR TITLE
added version number for channel deployment

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -35,7 +35,7 @@ const PUBLIC_KEY_LENGTH = 9;
 
 const MIN_BOTTOM_CLEARANCE = 0.7;
 
-const VERSION_NUMBER = "1.0.5";
+const VERSION_NUMBER = "1.0.5.01";
 
 const ARGUABLY_CLEVER_PHRASES = [
   "Please wait!",


### PR DESCRIPTION
This just updates the version number to 1.05.01. The idea is that this is merged to dev, then main, then published to the expo channel so that current iOS/Android users on 1.0.5 get the update that fixes the save location of images.