### PR TITLE
change authDomain

### DIFF
--- a/FirebaseApp.ts
+++ b/FirebaseApp.ts
@@ -7,7 +7,7 @@ import "firebase/storage"; // for jest testing purposes
 
 const firebaseConfig = {
   apiKey: "AIzaSyANqRXsUQIKxT9HtG4gIQ6EmsKEMCzCyuo",
-  authDomain: "pixstery-7c9b9.firebaseapp.com",
+  authDomain: "pixtery.io",
   databaseURL: "https://pixstery-7c9b9-default-rtdb.firebaseio.com",
   projectId: "pixstery-7c9b9",
   storageBucket: "pixstery-7c9b9.appspot.com",


### PR DESCRIPTION
Verification texts say pixtery.io now. Unfortunately the .io has to stay and capitalizing doesn't matter.