### PR TITLE
calendar in approval shows previous dailies

### DIFF
--- a/components/DailyCalendar.tsx
+++ b/components/DailyCalendar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import { Headline, IconButton } from "react-native-paper";
+import Toast from "react-native-root-toast";
 import { useSelector } from "react-redux";
 
 import { RootState, ScreenNavigation } from "../types";
@@ -17,6 +18,20 @@ export default function DailyCalendar({
   const receivedPuzzles = useSelector(
     (state: RootState) => state.receivedPuzzles
   );
+
+  const onUnmarkedDayPress = (dailyDate: string) => {
+    Toast.show("Nothing on that date", {
+      duration: Toast.durations.SHORT,
+      position: Toast.positions.CENTER,
+    });
+  };
+
+  const onMarkedDayPress = (dateString: string, markedDates: any) => {
+    const { puzzle } = markedDates[dateString];
+    navigation.navigate("GalleryReview", {
+      puzzle,
+    });
+  };
 
   return (
     <AdSafeAreaView
@@ -47,7 +62,10 @@ export default function DailyCalendar({
         <View
           style={{ flex: 1, alignContent: "center", justifyContent: "center" }}
         >
-          <DateSelect navigation={navigation} />
+          <DateSelect
+            onMarkedDayPress={onMarkedDayPress}
+            onUnmarkedDayPress={onUnmarkedDayPress}
+          />
           <IconButton
             icon="arrow-left"
             size={20}

--- a/components/DateSelect.tsx
+++ b/components/DateSelect.tsx
@@ -1,19 +1,20 @@
 import React, { useEffect, useState } from "react";
 import { Calendar } from "react-native-calendars";
 import { DateData } from "react-native-calendars/src/types";
-import Toast from "react-native-root-toast";
+import { ActivityIndicator, Text } from "react-native-paper";
 
 import { functions } from "../FirebaseApp";
-import { ScreenNavigation } from "../types";
 
 export default function DateSelect({
-  navigation,
-  addToCalendar,
+  onMarkedDayPress,
+  onUnmarkedDayPress,
 }: {
-  navigation: ScreenNavigation;
-  addToCalendar?: (date: string) => Promise<void>;
+  onMarkedDayPress: (date: string, markedDates?: any) => void;
+  onUnmarkedDayPress: (date: string) => void;
 }): JSX.Element {
   const [markedDates, setMarkedDates] = useState<any>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   const loadDailies = async (monthData: DateData) => {
     try {
@@ -28,7 +29,9 @@ export default function DateSelect({
       setMarkedDates(newDates);
     } catch (e) {
       console.log(e);
+      setError(true);
     }
+    setLoading(false);
   };
   useEffect(() => {
     const today = new Date();
@@ -42,29 +45,16 @@ export default function DateSelect({
     };
     loadDailies(monthData);
   }, []);
+  if (loading) return <ActivityIndicator size="small" />;
+  if (error) return <Text>Sorry, something went wrong.</Text>;
   return (
     <Calendar
       style={{ margin: 10 }}
       markedDates={markedDates}
       onDayPress={(day) => {
-        if (addToCalendar) {
-          if (!markedDates[day.dateString]) {
-            addToCalendar(day.dateString);
-          } else {
-            Toast.show("Pick unoccupied date", {
-              duration: Toast.durations.SHORT,
-              position: Toast.positions.CENTER,
-            });
-          }
-        } else {
-          if (markedDates[day.dateString]) {
-            const { puzzle } = markedDates[day.dateString];
-            navigation.navigate("GalleryReview", {
-              puzzle,
-              daily: true,
-            });
-          }
-        }
+        if (markedDates[day.dateString])
+          onMarkedDayPress(day.dateString, markedDates);
+        else onUnmarkedDayPress(day.dateString);
       }}
       onVisibleMonthsChange={(months) => {
         loadDailies(months[0]);

--- a/components/GalleryQueue.tsx
+++ b/components/GalleryQueue.tsx
@@ -93,19 +93,17 @@ export default function GalleryQueue({
         <Text style={{ color: "red", backgroundColor: "white" }}>
           {message}
         </Text>
-
-        <ScrollView
-          style={{
-            width: "100%",
-          }}
-        >
-          {loading ? (
-            <ActivityIndicator
-              animating
-              color={theme.colors.text}
-              size="small"
-            />
-          ) : (
+        {loading ? (
+          <ActivityIndicator animating color={theme.colors.text} size="small" />
+        ) : (
+          <>
+            <Button
+              icon="calendar"
+              mode="contained"
+              onPress={() => navigation.navigate("DailyCalendar")}
+            >
+              View Daily Calendar
+            </Button>
             <Button
               icon="reload"
               mode="contained"
@@ -114,7 +112,14 @@ export default function GalleryQueue({
             >
               Reload Queue (Max {limit} Results)
             </Button>
-          )}
+          </>
+        )}
+        <ScrollView
+          style={{
+            width: "100%",
+            flex: 1,
+          }}
+        >
           {queue.map((puzzle) => (
             <TouchableOpacity
               onPress={() =>
@@ -151,22 +156,6 @@ export default function GalleryQueue({
             </TouchableOpacity>
           ))}
         </ScrollView>
-        <View
-          style={{
-            flexDirection: "row",
-            position: "absolute",
-            bottom: 10,
-            alignItems: "center",
-          }}
-        >
-          <Button
-            icon="calendar"
-            mode="contained"
-            onPress={() => navigation.navigate("DailyCalendar")}
-          >
-            View Daily Calendar
-          </Button>
-        </View>
       </View>
     </AdSafeAreaView>
   );

--- a/types.ts
+++ b/types.ts
@@ -85,7 +85,7 @@ export type StackScreens = {
   Gallery: undefined;
   AddToGallery: undefined;
   GalleryQueue: undefined | { forceReload: boolean };
-  GalleryReview: { puzzle: Puzzle; daily?: boolean };
+  GalleryReview: { puzzle: Puzzle };
   DailyCalendar: undefined;
 };
 


### PR DESCRIPTION
This is in response to Fu's request for the admin workflow.

When you approve an item in the Queue, it shows you the calendar, but if you choose an occupied date, instead of a Toast pop up telling you it's occupied, you are instead directed to the Daily on that date, and you can remove that Daily or just go back to the Queue item you were reviewing.

One thing this doesn't do is navigate you back to the Queue item you were originally reviewing if you decide to delete the Daily (navigates you back to the Admin page instead). That would be a better flow, obviously, but then we'd have to keep track of what Queue item you were reviewing, pass that around, etc, and that seems more trouble than it's worth for the relatively infrequent situation of wanting to delete some stuff from the Daily at the same time as you review something in the Queue. If that happens, you'll just have to go back to reviewing what you were reviewing.