### PR TITLE
notification when your Pixtery chosen

### DIFF
--- a/components/AddToGallery.tsx
+++ b/components/AddToGallery.tsx
@@ -35,6 +35,9 @@ export default function AddToGallery({
   navigation: ScreenNavigation;
 }): JSX.Element {
   const theme = useSelector((state: RootState) => state.theme);
+  const notificationToken = useSelector(
+    (state: RootState) => state.notificationToken
+  );
   const receivedPuzzles = useSelector(
     (state: RootState) => state.receivedPuzzles
   );
@@ -154,11 +157,13 @@ export default function AddToGallery({
                   const addToQueue = functions.httpsCallable("addToQueue");
                   try {
                     const newPublicKey: string = shortid.generate();
+                    console.log(notificationToken);
                     await addToQueue({
                       publicKey,
                       anonymousChecked,
                       message,
                       newPublicKey,
+                      notificationToken,
                     });
                     Toast.show(
                       "Thanks for your submission! The Pixtery team will review soon!",

--- a/functions/src/fns/galleryFns.ts
+++ b/functions/src/fns/galleryFns.ts
@@ -65,6 +65,8 @@ export const addToGallery = functions.https.onCall(
         .set(
           {
             ...puzzleData,
+            //figured this would be good to remove from the 'live' gallery bc it's sent out to everyone
+            notificationToken: null,
             addedBy: context.auth.uid,
             addedOn: new Date(),
             // currently will overwrite an existing daily at the date

--- a/functions/src/fns/queueFns.ts
+++ b/functions/src/fns/queueFns.ts
@@ -96,8 +96,7 @@ export const addToQueue = functions.https.onCall(
         );
       }
 
-      const { publicKey, message, newPublicKey } = data;
-
+      const { publicKey, message, newPublicKey, notificationToken } = data;
       // get the puzzle data
       const res = await db.collection("pixteries").doc(publicKey).get();
       const puzzleData = res.data();
@@ -132,6 +131,7 @@ export const addToQueue = functions.https.onCall(
           .set(
             {
               ...puzzleData,
+              notificationToken,
               publicKey: newPublicKey,
               message,
               active: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "expo-image-picker": "~10.1.4",
         "expo-linking": "~2.2.3",
         "expo-media-library": "~12.0.2",
+        "expo-notifications": "~0.11.6",
         "expo-splash-screen": "~0.10.2",
         "expo-status-bar": "~1.0.4",
         "expo-store-review": "~4.0.2",
@@ -2519,6 +2520,11 @@
       "dependencies": {
         "@hapi/hoek": "^8.3.0"
       }
+    },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -6031,6 +6037,17 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/assert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+      "dependencies": {
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -6788,6 +6805,11 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
+    },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -8942,6 +8964,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
+    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -10375,6 +10402,85 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/expo-notifications": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.11.6.tgz",
+      "integrity": "sha512-skVEOHXKXrXBWofCQ/Zn7yKhAFA2EN0fd9mXqpkbF6nE4NKE7pn63gTWpyCy6sXC9M3YUal8yT0vp9GkD2FsmA==",
+      "dependencies": {
+        "@expo/config-plugins": "^1.0.18",
+        "@expo/image-utils": "^0.3.10",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~3.1.2",
+        "expo-constants": "10.1.3",
+        "fs-extra": "^9.0.1",
+        "unimodules-permissions-interface": "~6.1.0",
+        "uuid": "^3.4.0"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/config-plugins": {
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.33.tgz",
+      "integrity": "sha512-YQJop0c69LKD/6ZJJto7klS7TDmzgs44TI0Z5RBqesOjYlDwNFcQk2Rl2BaA1wlAYkH+rRrhN2+WjjSyD9HiPg==",
+      "dependencies": {
+        "@expo/config-types": "^40.0.0-beta.2",
+        "@expo/configure-splash-screen": "0.4.0",
+        "@expo/image-utils": "0.3.14",
+        "@expo/json-file": "8.2.30",
+        "@expo/plist": "0.0.13",
+        "find-up": "~5.0.0",
+        "fs-extra": "9.0.0",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "resolve-from": "^5.0.0",
+        "slash": "^3.0.0",
+        "xcode": "^3.0.1",
+        "xml2js": "^0.4.23"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/config-plugins/node_modules/fs-extra": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/config-types": {
+      "version": "40.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-40.0.0-beta.2.tgz",
+      "integrity": "sha512-t9pHCQMXOP4nwd7LGXuHkLlFy0JdfknRSCAeVF4Kw2/y+5OBbR9hW9ZVnetpBf0kORrekgiI7K/qDaa3hh5+Qg=="
+    },
+    "node_modules/expo-notifications/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/expo-permissions": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/expo-permissions/-/expo-permissions-12.0.1.tgz",
@@ -11602,6 +11708,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -12373,6 +12493,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -12388,6 +12522,21 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
       "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -25326,6 +25475,19 @@
         "pako": "^1.0.5"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -28232,6 +28394,11 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -31030,6 +31197,17 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "assert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+      "requires": {
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
+      }
+    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -31621,6 +31799,11 @@
         "babel-plugin-jest-hoist": "^25.5.0",
         "babel-preset-current-node-syntax": "^0.1.2"
       }
+    },
+    "badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -33309,6 +33492,11 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -34480,6 +34668,82 @@
         }
       }
     },
+    "expo-notifications": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.11.6.tgz",
+      "integrity": "sha512-skVEOHXKXrXBWofCQ/Zn7yKhAFA2EN0fd9mXqpkbF6nE4NKE7pn63gTWpyCy6sXC9M3YUal8yT0vp9GkD2FsmA==",
+      "requires": {
+        "@expo/config-plugins": "^1.0.18",
+        "@expo/image-utils": "^0.3.10",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~3.1.2",
+        "expo-constants": "10.1.3",
+        "fs-extra": "^9.0.1",
+        "unimodules-permissions-interface": "~6.1.0",
+        "uuid": "^3.4.0"
+      },
+      "dependencies": {
+        "@expo/config-plugins": {
+          "version": "1.0.33",
+          "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.33.tgz",
+          "integrity": "sha512-YQJop0c69LKD/6ZJJto7klS7TDmzgs44TI0Z5RBqesOjYlDwNFcQk2Rl2BaA1wlAYkH+rRrhN2+WjjSyD9HiPg==",
+          "requires": {
+            "@expo/config-types": "^40.0.0-beta.2",
+            "@expo/configure-splash-screen": "0.4.0",
+            "@expo/image-utils": "0.3.14",
+            "@expo/json-file": "8.2.30",
+            "@expo/plist": "0.0.13",
+            "find-up": "~5.0.0",
+            "fs-extra": "9.0.0",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "resolve-from": "^5.0.0",
+            "slash": "^3.0.0",
+            "xcode": "^3.0.1",
+            "xml2js": "^0.4.23"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "9.0.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+              "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+              "requires": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^1.0.0"
+              }
+            }
+          }
+        },
+        "@expo/config-types": {
+          "version": "40.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-40.0.0-beta.2.tgz",
+          "integrity": "sha512-t9pHCQMXOP4nwd7LGXuHkLlFy0JdfknRSCAeVF4Kw2/y+5OBbR9hW9ZVnetpBf0kORrekgiI7K/qDaa3hh5+Qg=="
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          },
+          "dependencies": {
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+            }
+          }
+        }
+      }
+    },
     "expo-permissions": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/expo-permissions/-/expo-permissions-12.0.1.tgz",
@@ -35475,6 +35739,14 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -36039,6 +36311,14 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="
     },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -36051,6 +36331,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
       "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
+    },
+    "is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
     },
     "is-negative-zero": {
       "version": "2.0.1",
@@ -46176,6 +46465,19 @@
       "integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
       "requires": {
         "pako": "^1.0.5"
+      }
+    },
+    "util": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "redux-thunk": "^2.3.0",
     "shortid": "^2.2.16",
     "tslib": "^2.1.0",
-    "uuid": "^3.3.2"
+    "uuid": "^3.3.2",
+    "expo-notifications": "~0.11.6"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",

--- a/store/index.ts
+++ b/store/index.ts
@@ -2,6 +2,7 @@ import { combineReducers, createStore, applyMiddleware } from "redux";
 import thunk from "redux-thunk";
 
 import adHeight from "./reducers/adHeight";
+import notificationToken from "./reducers/notificationToken";
 import profile from "./reducers/profile";
 import receivedPuzzles from "./reducers/receivedPuzzles";
 import screenHeight from "./reducers/screenHeight";
@@ -11,6 +12,7 @@ import theme from "./reducers/theme";
 import tutorialFinished from "./reducers/tutorialFinished";
 
 const reducer = combineReducers({
+  notificationToken,
   screenHeight,
   receivedPuzzles,
   sentPuzzles,

--- a/store/reducers/notificationToken.ts
+++ b/store/reducers/notificationToken.ts
@@ -1,0 +1,32 @@
+import { AnyAction } from "redux";
+
+// action types
+
+const SET_TOKEN = "SET_TOKEN";
+
+// action creators
+
+export const setNotificationToken = (token: string): AnyAction => {
+  return {
+    type: SET_TOKEN,
+    token,
+  };
+};
+
+// reducer
+
+const initialState = null;
+
+function reducer(
+  state: string | null = initialState,
+  action: AnyAction
+): string | null {
+  switch (action.type) {
+    case SET_TOKEN:
+      return action.token;
+    default:
+      return state;
+  }
+}
+
+export default reducer;

--- a/types.ts
+++ b/types.ts
@@ -36,6 +36,7 @@ export interface Puzzle {
   dateReceived?: string;
   completed?: boolean;
   dailyDate?: string;
+  notificationToken?: string;
 }
 
 export interface Profile {
@@ -118,6 +119,7 @@ export interface RootState {
   adHeight: number;
   tutorialFinished: boolean;
   sound: Audio.Sound | null;
+  notificationToken: string;
 }
 
 export type PixteryTheme = Theme & { name: string; ID: number };


### PR DESCRIPTION
In our last meeting, we talked about how it would be nice to be notified if your Pixtery was selected as a Daily. Expo makes this fairly easy for us. Here's how it works:
- when you open the App, you're assigned an Expo notification token. These never/very rarely change (uninstall/reinstall kind of thing)
- when you submit a Pixtery to the Queue, your notification token is included in Firebase.
- when an admin reviews and approves your Pixtery (with notification token) for a particular day, the admin also POSTs the notification token to an Expo API route. That triggers some Expo service that sends you a notification.

You can test this by running w function emulators, submitting a new Daily suggestion (has to be new so that it has your notification token), reviewing that suggestion and approving it for a particular day. You should get an Expo notification saying Congrats blah blah blah.

I think there's some more configuring to be done for the actual iOS and Android binary builds, but that can be figured out in another PR.