### PR TITLE
added creator name to puzzles on solve

### DIFF
--- a/components/Puzzle.tsx
+++ b/components/Puzzle.tsx
@@ -363,6 +363,11 @@ export default function PuzzleComponent({
               />
               <View style={styles(styleProps).winContainer}>
                 <Text style={styles(styleProps).winText}>{winMessage}</Text>
+                <Text style={styles(styleProps).creatorText}>
+                  {winMessage.length
+                    ? `created by: ${puzzle.senderName}`
+                    : null}
+                </Text>
               </View>
               <Button
                 icon="download-circle"
@@ -445,14 +450,22 @@ const styles = (props: { theme: Theme; boardSize: number }) =>
       zIndex: -1,
     },
     winContainer: {
-      flexDirection: "row",
+      flexDirection: "column",
       zIndex: 1,
     },
     winText: {
       fontSize: 25,
       flexWrap: "wrap",
       textAlign: "center",
-      flex: 1,
+      // flex: 1,
+      color: props.theme.colors.text,
+      marginTop: 20,
+    },
+    creatorText: {
+      fontSize: 15,
+      flexWrap: "wrap",
+      textAlign: "right",
+      // flex: 1,
       color: props.theme.colors.text,
       marginTop: 20,
     },


### PR DESCRIPTION
Very small PR to add "created by: " at the bottom of a puzzle when solved, for both Daily and regular Pixteries. I think we can use the same layout for both Daily and regular. I kind of like "created by: Anonymous" for Dailies when the sender chooses that option, but could also consider conditionally excluding that text altogether for anonymous Dailies.