### PR TITLE
remove react imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended",
     "plugin:prettier/recommended",

--- a/App.tsx
+++ b/App.tsx
@@ -10,7 +10,7 @@ import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { requestTrackingPermissionsAsync } from "expo-tracking-transparency";
 import * as Updates from "expo-updates";
-import React, { useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
 import { Alert, AppState, LogBox, Dimensions, Platform } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { Provider as PaperProvider } from "react-native-paper";

--- a/components/AdminScreens/DailyCalendar.tsx
+++ b/components/AdminScreens/DailyCalendar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { View } from "react-native";
 import { Headline, IconButton } from "react-native-paper";
 import Toast from "react-native-root-toast";

--- a/components/AdminScreens/GalleryQueue.tsx
+++ b/components/AdminScreens/GalleryQueue.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { View, ScrollView, TouchableOpacity } from "react-native";
 import {
   Headline,

--- a/components/AdminScreens/GalleryReview.tsx
+++ b/components/AdminScreens/GalleryReview.tsx
@@ -1,5 +1,5 @@
 import * as FileSystem from "expo-file-system";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { View, Image } from "react-native";
 import {
   ActivityIndicator,

--- a/components/Containers/AdminContainer.tsx
+++ b/components/Containers/AdminContainer.tsx
@@ -1,5 +1,4 @@
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import React from "react";
 
 import { StackScreens } from "../../types";
 import { GalleryQueue, GalleryReview, DailyCalendar } from "../AdminScreens";

--- a/components/Containers/DailyContainer.tsx
+++ b/components/Containers/DailyContainer.tsx
@@ -1,5 +1,4 @@
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import React from "react";
 
 import { StackScreens } from "../../types";
 import { Subheader } from "../Layout";

--- a/components/Containers/LibraryContainer.tsx
+++ b/components/Containers/LibraryContainer.tsx
@@ -1,5 +1,4 @@
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import React from "react";
 
 import { StackScreens } from "../../types";
 import { Subheader } from "../Layout";

--- a/components/Containers/MakeContainer.tsx
+++ b/components/Containers/MakeContainer.tsx
@@ -1,5 +1,5 @@
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import React from "react";
+
 import { useSelector } from "react-redux";
 
 import { RootState, StackScreens } from "../../types";

--- a/components/Containers/PuzzleListContainer.tsx
+++ b/components/Containers/PuzzleListContainer.tsx
@@ -1,5 +1,5 @@
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
-import React from "react";
+
 import { useSelector } from "react-redux";
 
 import { RootState, StackScreens } from "../../types";

--- a/components/Containers/SettingsContainer.tsx
+++ b/components/Containers/SettingsContainer.tsx
@@ -1,5 +1,4 @@
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import React from "react";
 
 import { StackScreens } from "../../types";
 import { Subheader } from "../Layout";

--- a/components/Containers/TabContainer.tsx
+++ b/components/Containers/TabContainer.tsx
@@ -4,7 +4,7 @@ import {
   FontAwesome,
 } from "@expo/vector-icons";
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
-import React from "react";
+
 import { View } from "react-native";
 import {
   SafeAreaView,

--- a/components/InteractiveElements/ConfirmDeleteModal.tsx
+++ b/components/InteractiveElements/ConfirmDeleteModal.tsx
@@ -1,5 +1,5 @@
 import { useNavigation } from "@react-navigation/native";
-import React, { useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import Modal from "react-native-modal";
 import {

--- a/components/InteractiveElements/DateSelect.tsx
+++ b/components/InteractiveElements/DateSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Calendar } from "react-native-calendars";
 import { DateData } from "react-native-calendars/src/types";
 import { ActivityIndicator, Text } from "react-native-paper";

--- a/components/InteractiveElements/IosCamera.tsx
+++ b/components/InteractiveElements/IosCamera.tsx
@@ -2,7 +2,7 @@
 import * as ImageManipulator from "expo-image-manipulator";
 import * as ImagePicker from "expo-image-picker";
 import { ImageInfo } from "expo-image-picker/build/ImagePicker.types";
-import React, { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { Animated, ImageBackground, View, Button, Modal } from "react-native";
 import {
   PanGestureHandler,

--- a/components/InteractiveElements/NameModal.tsx
+++ b/components/InteractiveElements/NameModal.tsx
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import React, { useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import Modal from "react-native-modal";
 import { Button, TextInput } from "react-native-paper";

--- a/components/InteractiveElements/PuzzlePiece.tsx
+++ b/components/InteractiveElements/PuzzlePiece.tsx
@@ -1,6 +1,6 @@
 import * as Haptics from "expo-haptics";
 import * as ImageManipulator from "expo-image-manipulator";
-import React, { useRef } from "react";
+import { useRef } from "react";
 import { Animated } from "react-native";
 import {
   PanGestureHandler,

--- a/components/InteractiveElements/ThemeModal.tsx
+++ b/components/InteractiveElements/ThemeModal.tsx
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import React from "react";
+
 import { ScrollView, View, TouchableOpacity } from "react-native";
 import Modal from "react-native-modal";
 import { Headline, Text } from "react-native-paper";

--- a/components/Layout/AdSafeAreaView.tsx
+++ b/components/Layout/AdSafeAreaView.tsx
@@ -1,7 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { AdMobBanner } from "expo-ads-admob";
 import * as StoreReview from "expo-store-review";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { StyleProp, ViewStyle, View, LayoutChangeEvent } from "react-native";
 import { useDispatch, useSelector } from "react-redux";
 

--- a/components/Layout/Subheader.tsx
+++ b/components/Layout/Subheader.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { Header, HeaderBackButton } from "@react-navigation/elements";
 import { ParamListBase } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import React from "react";
+
 import { Button } from "react-native-paper";
 import { useSelector } from "react-redux";
 

--- a/components/SignInMethods/Email/Email.tsx
+++ b/components/SignInMethods/Email/Email.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 
 import {
   sendResetEmail,

--- a/components/SignInMethods/Email/ForgotScreen.tsx
+++ b/components/SignInMethods/Email/ForgotScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import {
   Text,

--- a/components/SignInMethods/Email/RegisterScreen.tsx
+++ b/components/SignInMethods/Email/RegisterScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import {
   Text,

--- a/components/SignInMethods/Email/SignInScreen.tsx
+++ b/components/SignInMethods/Email/SignInScreen.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider } from "@react-navigation/native";
-import React, { useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import {
   Text,

--- a/components/SignInMethods/Phone/Phone.tsx
+++ b/components/SignInMethods/Phone/Phone.tsx
@@ -1,5 +1,5 @@
 import * as FirebaseRecaptcha from "expo-firebase-recaptcha";
-import React, { useState, useRef } from "react";
+import { useState, useRef } from "react";
 import { View } from "react-native";
 import {
   Text,

--- a/components/SignInMethods/ProfileModal.tsx
+++ b/components/SignInMethods/ProfileModal.tsx
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import React, { useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import Modal from "react-native-modal";
 import { useDispatch, useSelector } from "react-redux";

--- a/components/SignInMethods/SignInMenu.tsx
+++ b/components/SignInMethods/SignInMenu.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Button } from "react-native-paper";
 
 import { SignInOptions } from "../../types";

--- a/components/SignInMethods/SignInModal.tsx
+++ b/components/SignInMethods/SignInModal.tsx
@@ -1,5 +1,5 @@
 import { useNavigation } from "@react-navigation/native";
-import React from "react";
+
 import { View } from "react-native";
 import Modal from "react-native-modal";
 import { useSelector } from "react-redux";

--- a/components/StaticElements/DailyAgreement.tsx
+++ b/components/StaticElements/DailyAgreement.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Linking, View } from "react-native";
 import { Text } from "react-native-paper";
 

--- a/components/StaticElements/LoadingModal.tsx
+++ b/components/StaticElements/LoadingModal.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { View } from "react-native";
 import Modal from "react-native-modal";
 import { ActivityIndicator } from "react-native-paper";

--- a/components/StaticElements/UserAgreement.tsx
+++ b/components/StaticElements/UserAgreement.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Linking } from "react-native";
 import { Text } from "react-native-paper";
 

--- a/components/TransitionScreens/Splash.tsx
+++ b/components/TransitionScreens/Splash.tsx
@@ -1,7 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Audio } from "expo-av";
 import * as Linking from "expo-linking";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { View } from "react-native";
 import { ActivityIndicator } from "react-native-paper";
 import { useDispatch, useSelector } from "react-redux";

--- a/components/TransitionScreens/TitleScreen.tsx
+++ b/components/TransitionScreens/TitleScreen.tsx
@@ -1,6 +1,5 @@
 // this component is purely presentational to give the stack navigator something to show while it waits for the navigation container to finish initializing
 
-import React from "react";
 import { View } from "react-native";
 import { useSelector } from "react-redux";
 

--- a/components/UserScreens/ContactUs.tsx
+++ b/components/UserScreens/ContactUs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Keyboard, Text, Linking, View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { Button, TextInput } from "react-native-paper";

--- a/components/UserScreens/CreateProfile.tsx
+++ b/components/UserScreens/CreateProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { Text, Button, Headline } from "react-native-paper";

--- a/components/UserScreens/EnterName.tsx
+++ b/components/UserScreens/EnterName.tsx
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import React, { useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { Text, TextInput, Button, Headline } from "react-native-paper";

--- a/components/UserScreens/Gallery.tsx
+++ b/components/UserScreens/Gallery.tsx
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone"; // dependent on utc plugin
 import utc from "dayjs/plugin/utc";
 import { AdMobInterstitial } from "expo-ads-admob";
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { View, TouchableOpacity } from "react-native";
 import { ActivityIndicator, Button, Text } from "react-native-paper";
 import Toast from "react-native-root-toast";

--- a/components/UserScreens/ManagePuzzles.tsx
+++ b/components/UserScreens/ManagePuzzles.tsx
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import React, { useState } from "react";
+import { useState } from "react";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { Button } from "react-native-paper";
 import { useDispatch, useSelector } from "react-redux";

--- a/components/UserScreens/Profile.tsx
+++ b/components/UserScreens/Profile.tsx
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import React, { useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { Text, Button, Switch, IconButton } from "react-native-paper";

--- a/components/UserScreens/Puzzle.tsx
+++ b/components/UserScreens/Puzzle.tsx
@@ -2,7 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Audio } from "expo-av";
 import * as FileSystem from "expo-file-system";
 import * as ImageManipulator from "expo-image-manipulator";
-import React, { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { Text, View, StyleSheet, Image, LayoutChangeEvent } from "react-native";
 import Modal from "react-native-modal";
 import { ActivityIndicator, Button, Headline } from "react-native-paper";

--- a/components/UserScreens/Settings.tsx
+++ b/components/UserScreens/Settings.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { Text, Button } from "react-native-paper";
 import { useDispatch, useSelector } from "react-redux";

--- a/components/UserScreens/Tutorial.tsx
+++ b/components/UserScreens/Tutorial.tsx
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import React, { useState } from "react";
+import { useState } from "react";
 import { Image, View } from "react-native";
 import {
   Button,

--- a/tests/App.test.js
+++ b/tests/App.test.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { create } from "react-test-renderer";
 import TestRenderer from "react-test-renderer";
 import ShallowRenderer from "react-test-renderer/shallow";

--- a/tests/Header.test.js
+++ b/tests/Header.test.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { create, act } from "react-test-renderer";
 import TestRenderer from "react-test-renderer";
 import ShallowRenderer from "react-test-renderer/shallow";

--- a/tests/Home.test.js
+++ b/tests/Home.test.js
@@ -1,4 +1,3 @@
-import React from "react";
 import { create, act } from "react-test-renderer";
 import ShallowRenderer from "react-test-renderer/shallow";
 import {

--- a/tests/Puzzle.test.js
+++ b/tests/Puzzle.test.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { create, act } from "react-test-renderer";
 import ShallowRenderer from "react-test-renderer/shallow";
 import {


### PR DESCRIPTION
Minor nicety. This Expo SDK supports a new "JSX transform" that doesn't require that you import React at the top of every file using JSX. Slightly less code.