### PR TITLE
disable new line

### DIFF
--- a/components/InteractiveElements/MessageInput.tsx
+++ b/components/InteractiveElements/MessageInput.tsx
@@ -51,7 +51,11 @@ export default function MessageInput({
           multiline
           maxLength={messageLimit}
           value={message}
-          onChangeText={(message) => setMessage(message)}
+          onChangeText={(message) => {
+            if (message[message.length - 1] !== "\n") {
+              setMessage(message);
+            }
+          }}
           placeholderTextColor={theme.colors.text}
           onFocus={() => setMessageFocus(true)}
           onBlur={() => setMessageFocus(false)}


### PR DESCRIPTION
When entering a puzzle message you could hit return a bunch of times, which would push the Save Image button off screen no matter what we do. So I disabled the return key.