### PR TITLE
save image last

### DIFF
--- a/components/TransitionScreens/AddPuzzle.tsx
+++ b/components/TransitionScreens/AddPuzzle.tsx
@@ -75,7 +75,6 @@ export default function AddPuzzle({
 
   const savePuzzle = async (newPuzzle: Puzzle) => {
     try {
-      await downloadImage(newPuzzle);
       // save puzzle data to localStorage
       const allPuzzles = [
         newPuzzle,
@@ -83,6 +82,7 @@ export default function AddPuzzle({
       ];
       await AsyncStorage.setItem(storageItem, JSON.stringify(allPuzzles));
       dispatch(setPuzzles(allPuzzles));
+      await downloadImage(newPuzzle);
     } catch (error) {
       console.log(error);
       if (error instanceof Error) throw new Error(error.message); //rethrow error for outer method


### PR DESCRIPTION
Changed the order of steps in saving a puzzle, so we save puzzle data even if there's an issue with downloading the image. This way you'll have a card to press in your received list and don't have to find the key or link again if you want to try to download later.

Use `O4RMpKPSV` to test it.

Do we like this flow or no?