### PR TITLE
move api keys, admob IDs to gitignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ ip.ts
 serviceAccount.ts
 keystorecredentials.txt
 google-services.json
+admobIDs.js
+firebaseConfig.ts
 public/bundle*
 
 # macOS

--- a/FirebaseApp/InitializeFirebase.ts
+++ b/FirebaseApp/InitializeFirebase.ts
@@ -1,14 +1,5 @@
 import { initializeApp } from "firebase/app";
 
-export const firebaseConfig = {
-  apiKey: "AIzaSyANqRXsUQIKxT9HtG4gIQ6EmsKEMCzCyuo",
-  authDomain: "pixtery.io",
-  databaseURL: "https://pixstery-7c9b9-default-rtdb.firebaseio.com",
-  projectId: "pixstery-7c9b9",
-  storageBucket: "pixstery-7c9b9.appspot.com",
-  messagingSenderId: "503392467903",
-  appId: "1:503392467903:web:6283d87be13230e6caff0a",
-  measurementId: "G-5XDDLZ009P",
-};
+import firebaseConfig from "../firebaseConfig";
 
 export const app = initializeApp(firebaseConfig);

--- a/app.config.js
+++ b/app.config.js
@@ -1,8 +1,12 @@
+const admobIDs = require("./admobIDs");
 export default ({ config }) => {
-  return {
+  const _config = {
     ...config,
     extra: {
       functionEmulator: process.env.FUNC === "true",
     },
   };
+  _config.android.config.googleMobileAdsAppId = admobIDs.ANDROID_APP_ID;
+  _config.ios.config.googleMobileAdsAppId = admobIDs.IOS_APP_ID;
+  return _config;
 };

--- a/app.json
+++ b/app.json
@@ -32,7 +32,7 @@
       "supportsTablet": true,
       "appStoreUrl": "https://apps.apple.com/us/app/pixtery/id1569991739",
       "config": {
-        "googleMobileAdsAppId": "ca-app-pub-5028593996211038~8814734724"
+        "googleMobileAdsAppId": ""
       },
       "associatedDomains": ["applinks:pixtery.io"],
       "infoPlist": {
@@ -51,7 +51,7 @@
         "backgroundColor": "#C490D1"
       },
       "config": {
-        "googleMobileAdsAppId": "ca-app-pub-5028593996211038~3568139299"
+        "googleMobileAdsAppId": ""
       },
       "permissions": [
         "CAMERA",

--- a/components/SignInMethods/Phone/Phone.tsx
+++ b/components/SignInMethods/Phone/Phone.tsx
@@ -10,11 +10,8 @@ import {
 } from "react-native-paper";
 import { useSelector } from "react-redux";
 
-import {
-  phoneProvider,
-  firebaseConfig,
-  signInOnFireBase,
-} from "../../../FirebaseApp";
+import { phoneProvider, signInOnFireBase } from "../../../FirebaseApp";
+import firebaseConfig from "../../../firebaseConfig";
 import { RootState, SignInOptions } from "../../../types";
 
 const phoneFormat = require("phone");

--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,7 @@
 import { Platform } from "react-native";
 
+import admobIDs from "./admobIDs";
+
 const TESTING_MODE = false;
 
 const SNAP_MARGIN = 0.25;
@@ -11,16 +13,14 @@ const DEFAULT_IMAGE_SIZE = {
   height: 1080,
 };
 
-const TEST_BANNER_ID = "ca-app-pub-3940256099942544/6300978111";
-const ANDROID_BANNER_ID = "ca-app-pub-5028593996211038/4454679708";
-const IOS_BANNER_ID = "ca-app-pub-5028593996211038/6122984590";
+const {
+  IOS_BANNER_ID,
+  ANDROID_BANNER_ID,
+  IOS_INTERSTITIAL_ID,
+  ANDROID_INTERSTITIAL_ID,
+} = admobIDs;
 
 const BANNER_ID = Platform.OS === "ios" ? IOS_BANNER_ID : ANDROID_BANNER_ID;
-
-const TEST_INTERSTITIAL_ID = "ca-app-pub-3940256099942544/1033173712";
-const IOS_INTERSTITIAL_ID = "ca-app-pub-5028593996211038/9856183189";
-const ANDROID_INTERSTITIAL_ID = "ca-app-pub-5028593996211038/3290774832";
-
 const INTERSTITIAL_ID =
   Platform.OS === "ios" ? IOS_INTERSTITIAL_ID : ANDROID_INTERSTITIAL_ID;
 


### PR DESCRIPTION
This PR moves the Google AdMob IDs to their own file, and puts the Firebase config in its own file so that both can be gitignored and removed from this repo in order to make it public.

I don't think that either are technically much of a security risk. The Admob info can be gleaned from looking at the logs of the Android app (not sure about iOS), and of course the Firebase info is necessarily public. 

But I think this is good to do for two reasons: 
1) the Admob info could apparently be used maliciously if someone decided to create a bunch of "invalid" clicks on our ads and get us banned from the Admob program. Seems like a minor risk and you can appeal that, but it's not worth the hassle. The IDs do, though, need to be known by the client in order to get credit for your valid ad clicks, and so it's inherently not a secret, and if someone really wanted to mess with that, I think they could. This is just one small layer of security.
2) The Firebase info needs to be public, but it has the somewhat unfortunate name of "apiKey". I figure that doesn't look great to anyone browsing our repo and thinking that we don't know how to protect secrets like an API key. On top of that, with my other app, I left the API key in source and got a security alert email from Google saying that I had exposed an API key. It acknowledged that I may have intended it to be public, but, again, I figure this is just another small layer of security/way to sleep better.

Firebase has something called [App Check](https://firebase.google.com/docs/app-check?hl=en&authuser=0) that (I think) can help ensure that our DB is only accessed by our app or our website, helping to prevent fraud/abuse. We ought to also look into configuring that.

If this PR is approved, I'll run the same "cleanup" process I did on the repo history to remove any instance of the various IDs and keys.