### PR TITLE
fix add puzzle callback

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,6 +11,7 @@ web-build/
 .vscode
 *.bat
 functions/*.json
+serviceAccount.ts
 package-lock.json
 tests/
 patches

--- a/components/TransitionScreens/AddPuzzle.tsx
+++ b/components/TransitionScreens/AddPuzzle.tsx
@@ -172,7 +172,7 @@ export default function AddPuzzle({
         );
       };
       searchForPuzzle();
-    }, [route.params])
+    }, [])
   );
 
   return (

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "functions",
       "dependencies": {
         "@types/node": "^14.14.41",
         "cors": "^2.8.5",


### PR DESCRIPTION
Removed route.params from the dependency list in the callback in AddPuzzle to stop it from firing multiple times, which was causing puzzles to reload multiple times.

And added serviceaccount.ts to eslintignore because otherwise git wouldn't let me commit.