### PR TITLE
Build fixes

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,7 +3,7 @@ import {
   NavigationContainerRef,
 } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import Constants from "expo-constants";
+import * as Device from "expo-device";
 import * as Linking from "expo-linking";
 import * as Notifications from "expo-notifications";
 import { StatusBar } from "expo-status-bar";
@@ -66,7 +66,8 @@ const App = (): JSX.Element => {
       const isUpdate = await Updates.checkForUpdateAsync();
       if (isUpdate.isAvailable) {
         await Updates.fetchUpdateAsync();
-        promptRestart();
+        // commenting out the restart prompt but leaving the fetchUpdate so users get new version silently
+        // promptRestart();
       }
     } catch (error) {
       console.log(error);
@@ -101,7 +102,7 @@ const App = (): JSX.Element => {
     requestTrackingPermissions();
 
     const registerForPushNotificationsAsync = async () => {
-      if (Constants.isDevice) {
+      if (Device.isDevice) {
         const {
           status: existingStatus,
         } = await Notifications.getPermissionsAsync();

--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "slug": "pixtery",
     "privacy": "unlisted",
     "sdkVersion": "44.0.0",
-    "version": "2.0.5",
+    "version": "2.0.51",
     "platforms": ["android", "ios"],
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
@@ -28,7 +28,7 @@
     "assetBundlePatterns": ["assets/*"],
     "ios": {
       "bundleIdentifier": "com.fjamstudios.pixtery",
-      "buildNumber": "2.0.5",
+      "buildNumber": "2.0.51",
       "supportsTablet": true,
       "appStoreUrl": "https://apps.apple.com/us/app/pixtery/id1569991739",
       "config": {
@@ -44,7 +44,7 @@
     "android": {
       "package": "com.fjamstudios.pixtery",
       "googleServicesFile": "./google-services.json",
-      "versionCode": 11,
+      "versionCode": 12,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.fjamstudios.pixtery",
       "adaptiveIcon": {
         "foregroundImage": "./assets/icon.png",

--- a/components/AdminScreens/GalleryQueue.tsx
+++ b/components/AdminScreens/GalleryQueue.tsx
@@ -1,3 +1,4 @@
+import * as Updates from "expo-updates";
 import { useState, useEffect } from "react";
 import { View, ScrollView, TouchableOpacity } from "react-native";
 import {
@@ -79,6 +80,8 @@ export default function GalleryQueue({
         }}
       >
         <Headline>Submission Queue</Headline>
+        <Text>Release Channel: {Updates.releaseChannel}</Text>
+        <Text>ID: {Updates.updateId}</Text>
         <Text style={{ color: "red", backgroundColor: "white" }}>
           {message}
         </Text>

--- a/constants.ts
+++ b/constants.ts
@@ -1,3 +1,4 @@
+import * as Device from "expo-device";
 import { Platform } from "react-native";
 
 import admobIDs from "./admobIDs";
@@ -14,15 +15,21 @@ const DEFAULT_IMAGE_SIZE = {
 };
 
 const {
+  TEST_BANNER_ID,
   IOS_BANNER_ID,
   ANDROID_BANNER_ID,
+  TEST_INTERSTITIAL_ID,
   IOS_INTERSTITIAL_ID,
   ANDROID_INTERSTITIAL_ID,
 } = admobIDs;
 
-const BANNER_ID = Platform.OS === "ios" ? IOS_BANNER_ID : ANDROID_BANNER_ID;
-const INTERSTITIAL_ID =
-  Platform.OS === "ios" ? IOS_INTERSTITIAL_ID : ANDROID_INTERSTITIAL_ID;
+let BANNER_ID = TEST_BANNER_ID;
+let INTERSTITIAL_ID = TEST_INTERSTITIAL_ID;
+if (Device.isDevice) {
+  BANNER_ID = Platform.OS === "ios" ? IOS_BANNER_ID : ANDROID_BANNER_ID;
+  INTERSTITIAL_ID =
+    Platform.OS === "ios" ? IOS_INTERSTITIAL_ID : ANDROID_INTERSTITIAL_ID;
+}
 
 // so we don't have to deal w fullscreen ads before sending a test pixtery
 const DISPLAY_PAINFUL_ADS = false;
@@ -35,7 +42,7 @@ const PUBLIC_KEY_LENGTH = 9;
 
 const MIN_BOTTOM_CLEARANCE = 0.7;
 
-const VERSION_NUMBER = "2.0.5";
+const VERSION_NUMBER = "2.0.51";
 
 const ARGUABLY_CLEVER_PHRASES = [
   "Please wait!",

--- a/eas.json
+++ b/eas.json
@@ -24,6 +24,9 @@
         "buildType": "app-bundle"
       }
     },
+    "testflight": {
+      "releaseChannel": "internal-testing"
+    },
     "production": {}
   },
   "submit": {

--- a/eas.json
+++ b/eas.json
@@ -12,12 +12,14 @@
     },
     "preview:apk": {
       "distribution": "internal",
+      "releaseChannel": "internal-testing",
       "android": {
         "buildType": "apk"
       }
     },
     "preview:aab": {
       "distribution": "internal",
+      "releaseChannel": "internal-testing",
       "android": {
         "buildType": "app-bundle"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "expo-av": "~10.2.0",
         "expo-constants": "~13.0.0",
         "expo-dev-client": "~0.8.4",
+        "expo-device": "~4.1.0",
         "expo-file-system": "~13.1.4",
         "expo-firebase-recaptcha": "~2.1.0",
         "expo-haptics": "~11.1.0",
@@ -7628,6 +7629,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-device": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-4.1.1.tgz",
+      "integrity": "sha512-It0SGtKcvzQSf+Co6zdPdB63zZvG2/rDolB1lqswMNKj03Y7KVU41s5tcQCqNczj7tmeN3CJy7A8YhYGKdb7gA==",
+      "dependencies": {
+        "ua-parser-js": "^0.7.19"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-error-recovery": {
@@ -21890,6 +21902,14 @@
       "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-0.5.3.tgz",
       "integrity": "sha512-i1d7vtKILnq7mo6r5jSQ++UxkpP+VX/IkOAKuWGeB/B32pCTFCD32rplymFS3qPQ+vlmb5zKl5yhYSYZSVobhg==",
       "requires": {}
+    },
+    "expo-device": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-4.1.1.tgz",
+      "integrity": "sha512-It0SGtKcvzQSf+Co6zdPdB63zZvG2/rDolB1lqswMNKj03Y7KVU41s5tcQCqNczj7tmeN3CJy7A8YhYGKdb7gA==",
+      "requires": {
+        "ua-parser-js": "^0.7.19"
+      }
     },
     "expo-error-recovery": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "redux-thunk": "^2.4.1",
     "shortid": "^2.2.16",
     "tslib": "^2.3.1",
-    "uuid": "^3.4.0"
+    "uuid": "^3.4.0",
+    "expo-device": "~4.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
- disable promptRestart after there's a JS bundle update
- use expo-device instead of expo-constants, since constants.isDevice is deprecated
- add Device.isDevice check to admob IDs so that emulators only use test IDs
- change EAS build profiles to use 'internal-testing' release channel for preview/testflight builds
- show release channel name and JS bundle ID in the admin screen (useful for testing)
- update version num 2.0.51/Android build 12