### PR TITLE
revise make and addtogallery components

### DIFF
--- a/components/UserScreens/AddToGallery.tsx
+++ b/components/UserScreens/AddToGallery.tsx
@@ -1,24 +1,34 @@
 import * as FileSystem from "expo-file-system";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   ImageBackground,
   View,
   ScrollView,
   TouchableOpacity,
 } from "react-native";
-import { Card, Headline, IconButton, Text } from "react-native-paper";
+import { Button, Card, Headline, IconButton, Text } from "react-native-paper";
 import { useSelector } from "react-redux";
 
-import { RootState } from "../../types";
+import { DailyContainerProps, RootState } from "../../types";
 import { formatDateFromString } from "../../util";
 import { SubmissionModal } from "../InteractiveElements";
 import { AdSafeAreaView } from "../Layout";
 
-export default function AddToGallery(): JSX.Element {
+export default function AddToGallery({
+  navigation,
+  route,
+}: DailyContainerProps<"AddToGallery">): JSX.Element {
   const theme = useSelector((state: RootState) => state.theme);
   const sentPuzzles = useSelector((state: RootState) => state.sentPuzzles);
   const [modalVisible, setModalVisible] = useState(false);
   const [selectedPuzzle, setSelectedPuzzle] = useState<Puzzle>();
+
+  useEffect(() => {
+    if (route.params?.puzzle) {
+      setModalVisible(true);
+      setSelectedPuzzle(route.params.puzzle);
+    }
+  }, [route.params?.puzzle]);
 
   return (
     <AdSafeAreaView
@@ -30,13 +40,26 @@ export default function AddToGallery(): JSX.Element {
         justifyContent: "flex-start",
       }}
     >
+      <Button
+        icon="camera-iris"
+        mode="contained"
+        onPress={() => {
+          navigation.push("TabContainer", {
+            screen: "MakeContainer",
+            params: { screen: "Make", params: { directToDaily: true } },
+          });
+        }}
+        style={{ margin: 5 }}
+      >
+        Create a New Pixtery!
+      </Button>
       <ScrollView>
-        <Text style={{ alignSelf: "center", textAlign: "center" }}>
-          You can edit the secret message after selecting
-        </Text>
-        <>
-          {sentPuzzles.length ? (
-            sentPuzzles.map((sentPuzzle, ix) => (
+        {sentPuzzles.length ? (
+          <>
+            <Text style={{ alignSelf: "center", textAlign: "center" }}>
+              You can edit the secret message after selecting
+            </Text>
+            {sentPuzzles.map((sentPuzzle, ix) => (
               <TouchableOpacity
                 onPress={() => {
                   setModalVisible(true);
@@ -87,18 +110,19 @@ export default function AddToGallery(): JSX.Element {
                   />
                 </Card>
               </TouchableOpacity>
-            ))
-          ) : (
-            <View
-              style={{
-                alignItems: "center",
-              }}
-            >
-              <Headline>You haven&apos;t sent any puzzles!</Headline>
-            </View>
-          )}
-        </>
+            ))}
+          </>
+        ) : (
+          <View
+            style={{
+              alignItems: "center",
+            }}
+          >
+            <Headline>You haven&apos;t sent any puzzles!</Headline>
+          </View>
+        )}
       </ScrollView>
+
       {selectedPuzzle ? (
         <SubmissionModal
           modalVisible={modalVisible}

--- a/components/UserScreens/AddToGallery.tsx
+++ b/components/UserScreens/AddToGallery.tsx
@@ -1,5 +1,5 @@
 import * as FileSystem from "expo-file-system";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   ImageBackground,
   View,
@@ -20,15 +20,17 @@ export default function AddToGallery({
 }: DailyContainerProps<"AddToGallery">): JSX.Element {
   const theme = useSelector((state: RootState) => state.theme);
   const sentPuzzles = useSelector((state: RootState) => state.sentPuzzles);
-  const [modalVisible, setModalVisible] = useState(false);
-  const [selectedPuzzle, setSelectedPuzzle] = useState<Puzzle>();
 
-  useEffect(() => {
-    if (route.params?.puzzle) {
-      setModalVisible(true);
-      setSelectedPuzzle(route.params.puzzle);
-    }
-  }, [route.params?.puzzle]);
+  let modalState = false;
+  let loadedPuzzle = null;
+  if (route.params?.puzzle) {
+    modalState = true;
+    loadedPuzzle = route.params.puzzle;
+  }
+  const [modalVisible, setModalVisible] = useState(modalState);
+  const [selectedPuzzle, setSelectedPuzzle] = useState<Puzzle | null>(
+    loadedPuzzle
+  );
 
   return (
     <AdSafeAreaView

--- a/constants.ts
+++ b/constants.ts
@@ -31,9 +31,6 @@ if (Device.isDevice) {
     Platform.OS === "ios" ? IOS_INTERSTITIAL_ID : ANDROID_INTERSTITIAL_ID;
 }
 
-// so we don't have to deal w fullscreen ads before sending a test pixtery
-const DISPLAY_PAINFUL_ADS = false;
-
 const DEGREE_CONVERSION = Math.PI / 180;
 
 const USE_NATIVE_DRIVER = true;
@@ -65,7 +62,6 @@ export {
   DEFAULT_IMAGE_SIZE,
   BANNER_ID,
   INTERSTITIAL_ID,
-  DISPLAY_PAINFUL_ADS,
   DEGREE_CONVERSION,
   USE_NATIVE_DRIVER,
   PUBLIC_KEY_LENGTH,

--- a/types/navigation.ts
+++ b/types/navigation.ts
@@ -41,7 +41,7 @@ export type TabContainerProps<
 ///////////
 
 export type MakeContainerParamsList = {
-  Make: undefined;
+  Make: undefined | { directToDaily: boolean };
   Tutorial: undefined;
 };
 
@@ -56,7 +56,7 @@ export type MakeContainerProps<
 
 export type DailyContainerParamsList = {
   Gallery: undefined;
-  AddToGallery: undefined;
+  AddToGallery: { puzzle: Puzzle } | undefined;
 };
 
 export type DailyContainerProps<


### PR DESCRIPTION
Added "Create a New Pixtery" button to Daily Submission.
Make screen can either use the default flow or the direct-to-daily flow. D2D flow doesn't offer to share the link and instead navigates to the "confirm submission" screen.
D2D Pixteries are still added to your sent list. The Make screen is reset to default after navigating away.