### PR TITLE
Trim email address when submitted

### DIFF
--- a/components/SignInMethods/Email/RegisterScreen.tsx
+++ b/components/SignInMethods/Email/RegisterScreen.tsx
@@ -68,7 +68,7 @@ export default function RegisterScreen({
         icon="account"
         mode="contained"
         onPress={() =>
-          onPress(email, password, confirmPassword, setErrors, true)
+          onPress(email.trim(), password, confirmPassword, setErrors, true)
         }
         style={{ margin: 10 }}
         disabled={email.length === 0 || password.length === 0}

--- a/components/SignInMethods/Email/SignInScreen.tsx
+++ b/components/SignInMethods/Email/SignInScreen.tsx
@@ -56,7 +56,7 @@ export default function SignInScreen({
       <Button
         icon="camera-iris"
         mode="contained"
-        onPress={() => onPress(email, password, null, setErrors, false)}
+        onPress={() => onPress(email.trim(), password, null, setErrors, false)}
         style={{ margin: 10 }}
         disabled={email.length === 0 || password.length === 0}
       >

--- a/sentry.js
+++ b/sentry.js
@@ -1,6 +1,0 @@
-module.exports = {
-  AUTH_TOKEN:
-    "779d3ccff12b4cb1ac26a7a2ae1b851f22cc9a1a0ac441a3945c1345b2cc2879",
-  DSN:
-    "https://c8e5645714bf4f05b4c7a397d5d99bb3@o1207021.ingest.sentry.io/6340472",
-};

--- a/sentry.js
+++ b/sentry.js
@@ -1,0 +1,6 @@
+module.exports = {
+  AUTH_TOKEN:
+    "779d3ccff12b4cb1ac26a7a2ae1b851f22cc9a1a0ac441a3945c1345b2cc2879",
+  DSN:
+    "https://c8e5645714bf4f05b4c7a397d5d99bb3@o1207021.ingest.sentry.io/6340472",
+};


### PR DESCRIPTION
Tiny change, trims email addresses when submitted during sign-in/register so that people who accidentally enter emails that start or end with a space can proceed with the sign-in/register process