### PR TITLE
Ipad rendering and bottom border fix for puzzle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ google-services.json
 admobIDs.js
 firebaseConfig.ts
 public/bundle*
+sentry.js
 
 # macOS
 .DS_Store

--- a/components/InteractiveElements/PuzzlePiece.tsx
+++ b/components/InteractiveElements/PuzzlePiece.tsx
@@ -122,7 +122,7 @@ export default function PuzzlePiece({
         lastOffset.x
       );
       lastOffset.y = Math.min(
-        lowerBound - pieceDimensions.height * 0.5 - initialPlacement.y,
+        lowerBound - pieceDimensions.height - initialPlacement.y,
         lastOffset.y
       );
       // snap piece here using lastOffset, adjust for centered snapping points

--- a/components/UserScreens/Puzzle.tsx
+++ b/components/UserScreens/Puzzle.tsx
@@ -131,19 +131,15 @@ export default function PuzzleComponent({
       const { gridSize, puzzleType, imageURI } = pickedPuzzle;
       const squareSize = boardSize / gridSize;
       const numPieces = gridSize * gridSize;
-      const minSandboxY = boardSize * 1.01;
+      const topOfAd = puzzleAreaDimensions.puzzleAreaHeight - adHeight;
+      // minSandboxY (i.e. top of initial puzzle scatter area) is min of the bottom of board and top of ad banner minus the squaresize. Depending on the screen dimensions (i.e. iPad), sometimes the area below the board is smaller than the puzzle pieces.
+      const minSandboxY = Math.min(boardSize * 1.01, topOfAd - squareSize);
       // maxSandboxY (upper left max bound of initial piece position)
       // sometimes depending on screenheight, min is larger than max
-      const maxSandboxY = Math.max(
-        puzzleAreaDimensions.puzzleAreaHeight -
-          adHeight -
-          parentContainerStyle.padding * 2 -
-          squareSize,
-        minSandboxY
-      );
+      const maxSandboxY = Math.max(topOfAd - squareSize, minSandboxY);
+      console.log('adheight', adHeight, puzzleAreaDimensions.puzzleAreaHeight)
 
-      setLowerBound(maxSandboxY);
-
+      setLowerBound(topOfAd);
       setPuzzle(pickedPuzzle);
 
       const shuffleOrder = shuffle(fillArray(gridSize), disableShuffle);

--- a/components/UserScreens/Puzzle.tsx
+++ b/components/UserScreens/Puzzle.tsx
@@ -137,7 +137,6 @@ export default function PuzzleComponent({
       // maxSandboxY (upper left max bound of initial piece position)
       // sometimes depending on screenheight, min is larger than max
       const maxSandboxY = Math.max(topOfAd - squareSize, minSandboxY);
-      console.log('adheight', adHeight, puzzleAreaDimensions.puzzleAreaHeight)
 
       setLowerBound(topOfAd);
       setPuzzle(pickedPuzzle);


### PR DESCRIPTION
This PR addresses:

- Before, iPad was rendering pieces under the ad (i.e. ad banner was covering the pieces). This was because given that iPads have less height to width compared to phones, there was sometimes not enough space between the board and ad for the full piece. The previous logic still rendered the piece below the board, which is why it was forced to go beneath the ad. I changed the logic to overlap the board if it needs to (rather than under ad)

- Before, there was a small gap between the lowest a piece could go and the top of the ad. This PR attempts to address this, but with the caveat that this works for square puzzles (i.e. you can pull down the piece flush to top of ad), but for jigsaw, it still looks a little off. This is likely because initial placement (i.e. top of piece) is calculated before rotation. For square, that doesn't matter because the piece looks the same regardless of how it is rotated, but for jigsaw, the initial placement value is often not what is visually represented on the board. But I think this should still be an improvement for jigsaw as well.

I have tested on my end on multiple devices including iPad, but would definitely appreciate testing. 

**One thing that does not work:** when I enter a publicKey directly in the input box of Received puzzle list and test how far I can pull down a piece, it is lower and a small portion overlaps with the ad. So in other words, when I test a 3x3 square direct from a card in my received list vs entering a publicKey, it looks good for the former but a little off for the latter. I just discovered this so haven't looked into it in a lot of detail yet, but wanted to bring it up to see if anyone had any initial ideas of what could be happening.  