### PR TITLE
minimially usable app for iOS versions below 13

### DIFF
--- a/components/UserScreens/Make.tsx
+++ b/components/UserScreens/Make.tsx
@@ -86,7 +86,7 @@ export default function Make({
 
   const selectImage = async (camera: boolean) => {
     const permission = await checkPermission(camera);
-    // for ImagePicker.launchImageLibraryAsync ImagePicker.UIImagePickerPresentationStyle.Automatic is not supported for iOS versions below 13. Need to set to FullScreen for these older versions. 
+    // for ImagePicker.launchImageLibraryAsync ImagePicker.UIImagePickerPresentationStyle.Automatic is not supported for iOS versions below 13. Need to set to FullScreen for these older versions.
     const presentationStyle = iosVersionIsBelow13
       ? ImagePicker.UIImagePickerPresentationStyle.FullScreen
       : ImagePicker.UIImagePickerPresentationStyle.Automatic;

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "expo-firebase-recaptcha": "~2.1.0",
         "expo-haptics": "~11.1.0",
         "expo-image-manipulator": "~10.2.0",
-        "expo-image-picker": "~12.0.1",
+        "expo-image-picker": "~12.0.2",
         "expo-linking": "~3.0.0",
         "expo-media-library": "~14.0.0",
         "expo-notifications": "~0.14.0",
@@ -8293,9 +8293,9 @@
       }
     },
     "node_modules/expo-image-picker": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-12.0.1.tgz",
-      "integrity": "sha512-0utJK87zQH9jeOKlK51x/AXg43msef8qY+oib7TR12jVa6uuPmO8TcMgzr1UZ7DIsxlkMRId/cvBWzMu2BnJcg==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-12.0.2.tgz",
+      "integrity": "sha512-rAoNGtofV5cg3UN+cdIGDVfbMvbutBX6uNV7jCIEw/WZxZlbW+R7HC8l5lGDFtoLVqcpkHE/6JpAXvESxVSAOA==",
       "dependencies": {
         "@expo/config-plugins": "^4.0.2",
         "uuid": "7.0.2"
@@ -23460,9 +23460,9 @@
       }
     },
     "expo-image-picker": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-12.0.1.tgz",
-      "integrity": "sha512-0utJK87zQH9jeOKlK51x/AXg43msef8qY+oib7TR12jVa6uuPmO8TcMgzr1UZ7DIsxlkMRId/cvBWzMu2BnJcg==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-12.0.2.tgz",
+      "integrity": "sha512-rAoNGtofV5cg3UN+cdIGDVfbMvbutBX6uNV7jCIEw/WZxZlbW+R7HC8l5lGDFtoLVqcpkHE/6JpAXvESxVSAOA==",
       "requires": {
         "@expo/config-plugins": "^4.0.2",
         "uuid": "7.0.2"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "expo-firebase-recaptcha": "~2.1.0",
     "expo-haptics": "~11.1.0",
     "expo-image-manipulator": "~10.2.0",
-    "expo-image-picker": "~12.0.1",
+    "expo-image-picker": "~12.0.2",
     "expo-linking": "~3.0.0",
     "expo-media-library": "~14.0.0",
     "expo-notifications": "~0.14.0",


### PR DESCRIPTION
Currently for older iOS devices that are not supported beyond iOS version 13, the app crashes when user clicks Gallery and Camera buttons on the Make screen. This is because in SDK44 (our version), `UIImagePickerPresentationStyle.AUTOMATIC` is not supported. (FYI in the [latest SDK45 it is supported](https://docs.expo.dev/versions/v45.0.0/sdk/imagepicker/#uiimagepickerpresentationstyle), but given the very low market share of these older devices, in our last meeting we discussed this is not a big enough reason to upgrade to SDK45 at this time given the potential instability that comes with these upgrades).

This PR enables users with iOS versions below 13 to send pics without crashing:
- for the Gallery button i.e. `ImagePicker.launchImageLibraryAsync`, `presentationStyle` is set to `FullScreen` for iOS versions below 13 (based on [this fix](https://github.com/expo/expo/issues/14903#issuecomment-966161497))
- for Camera button, I have not found a similar fix for SDK44, so I have hid that button for iOS versions below 13 (screenshot below). 

I've confirmed on all my devices both old and new that this works, but could you all test Make on your devices to make sure nothing is broken? Your experience should not be different unless you also have the old device.

![IMG_0079](https://user-images.githubusercontent.com/59271264/173195003-73c88f0c-7350-4191-811b-d8fa76184c3c.PNG)