### PR TITLE
lock Orientation to portrait for ipads

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,7 +11,7 @@ import { StatusBar } from "expo-status-bar";
 import { requestTrackingPermissionsAsync } from "expo-tracking-transparency";
 import * as Updates from "expo-updates";
 import { useRef, useEffect } from "react";
-import { LogBox, Dimensions, Platform } from "react-native";
+import { LogBox, Dimensions, Platform, PlatformIOSStatic } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { Provider as PaperProvider } from "react-native-paper";
 import { RootSiblingParent } from "react-native-root-siblings";
@@ -66,7 +66,18 @@ const lockScreenOrientationToPortrait = async (
     await ScreenOrientation.lockAsync(orientationLock);
 };
 
-lockScreenOrientationToPortrait(ScreenOrientation.OrientationLock.PORTRAIT_UP);
+const isIpad = (): boolean => {
+  // analogous approach not available for android tablet
+  if (Platform.OS === "ios") {
+    const platformIOS = Platform as PlatformIOSStatic;
+    return platformIOS.isPad;
+  } else return false;
+};
+
+if (isIpad())
+  lockScreenOrientationToPortrait(
+    ScreenOrientation.OrientationLock.PORTRAIT_UP
+  );
 
 const App = (): JSX.Element => {
   const dispatch = useDispatch();

--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import * as Device from "expo-device";
 import * as Linking from "expo-linking";
 import * as Notifications from "expo-notifications";
+import * as ScreenOrientation from "expo-screen-orientation";
 import { StatusBar } from "expo-status-bar";
 import { requestTrackingPermissionsAsync } from "expo-tracking-transparency";
 import * as Updates from "expo-updates";
@@ -49,6 +50,23 @@ Sentry.init({
   enableInExpoDevelopment: true,
   debug: true, // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
 });
+
+const logScreenOrientation = async () => {
+  const getOrientationAsync = await ScreenOrientation.getOrientationAsync();
+  console.log("getOrientationAsync", getOrientationAsync);
+  const getOrientationLockAsync = await ScreenOrientation.getOrientationLockAsync();
+  console.log("getOrientationLockAsync", getOrientationLockAsync);
+};
+logScreenOrientation();
+
+const lockScreenOrientationToPortrait = async (
+  orientationLock: ScreenOrientation.OrientationLock
+): Promise<void> => {
+  if (await ScreenOrientation.supportsOrientationLockAsync(orientationLock))
+    await ScreenOrientation.lockAsync(orientationLock);
+};
+
+lockScreenOrientationToPortrait(ScreenOrientation.OrientationLock.PORTRAIT_UP);
 
 const App = (): JSX.Element => {
   const dispatch = useDispatch();

--- a/app.json
+++ b/app.json
@@ -39,7 +39,8 @@
         "NSCameraUsageDescription": "This app accesses your device camera so that you can take pictures with your camera to send as puzzles to others.",
         "NSPhotoLibraryUsageDescription": "This app accesses your device photo library so that you can select existing photos on your device to send as puzzles to others.",
         "NSUserTrackingUsageDescription": "This identifier will be used to deliver personalized ads to you."
-      }
+      },
+      "requireFullScreen": true
     },
     "android": {
       "package": "com.fjamstudios.pixtery",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "expo-linking": "~3.0.0",
         "expo-media-library": "~14.0.0",
         "expo-notifications": "~0.14.0",
+        "expo-screen-orientation": "~4.1.2",
         "expo-status-bar": "~1.2.0",
         "expo-store-review": "~5.1.0",
         "expo-tracking-transparency": "~2.1.0",
@@ -8442,6 +8443,17 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/expo-screen-orientation": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/expo-screen-orientation/-/expo-screen-orientation-4.1.2.tgz",
+      "integrity": "sha512-ZK9JnIuys3bL0IPIkBazBwc6dZambm2xxu0TEV7HYtowb769XLTFOJgVttrpeNDMXEt/22+dhCE4ZFaPNu6JlA==",
+      "dependencies": {
+        "@expo/config-plugins": "^4.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {
@@ -23588,6 +23600,14 @@
             }
           }
         }
+      }
+    },
+    "expo-screen-orientation": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/expo-screen-orientation/-/expo-screen-orientation-4.1.2.tgz",
+      "integrity": "sha512-ZK9JnIuys3bL0IPIkBazBwc6dZambm2xxu0TEV7HYtowb769XLTFOJgVttrpeNDMXEt/22+dhCE4ZFaPNu6JlA==",
+      "requires": {
+        "@expo/config-plugins": "^4.0.2"
       }
     },
     "expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "sentry-expo": "^4.0.0",
     "shortid": "^2.2.16",
     "tslib": "^2.3.1",
-    "uuid": "^3.4.0"
+    "uuid": "^3.4.0",
+    "expo-screen-orientation": "~4.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
As discussed, @mavirex could you test this out? I think you can just do `npm i` and then `expo start` in portrait, and see if you turn to landscape whether it locks or not. It does not work on mine, but could be because my iOS is lower than 13.