### PR TITLE
Web ad units

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,16 +16,16 @@
   <body>
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5028593996211038"
      crossorigin="anonymous"></script>
-<!-- web-ads-pixtery -->
-<ins class="adsbygoogle"
-     style="display:block"
-     data-ad-client="ca-pub-5028593996211038"
-     data-ad-slot="1403208591"
-     data-ad-format="auto"
-     data-full-width-responsive="true"></ins>
-<script>
-     (adsbygoogle = window.adsbygoogle || []).push({});
-</script>
+    <!-- web-ads-pixtery -->
+    <ins class="adsbygoogle"
+        style="display:block"
+        data-ad-client="ca-pub-5028593996211038"
+        data-ad-slot="1403208591"
+        data-ad-format="auto"
+        data-full-width-responsive="true"></ins>
+    <script>
+        (adsbygoogle = window.adsbygoogle || []).push({});
+    </script>
     <div id="root"></div>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,18 @@
   </head>
 
   <body>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5028593996211038"
+     crossorigin="anonymous"></script>
+<!-- web-ads-pixtery -->
+<ins class="adsbygoogle"
+     style="display:block"
+     data-ad-client="ca-pub-5028593996211038"
+     data-ad-slot="1403208591"
+     data-ad-format="auto"
+     data-full-width-responsive="true"></ins>
+<script>
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script>
     <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
This PR is to set up putting ads on the web page as we discussed. I created an AdSense account (I think we need to for web ads). Looking at the different options, I think [Display Ad Unit](https://support.google.com/adsense/answer/9274025?hl=en&visit_id=637954839594268044-2639553115&rd=1) is the best option for us (I wanted to do [Auto Ads](https://www.google.com/adsense/new/u/0/pub-5028593996211038/myads/sites), but I don't think it works for wildcard web links, which ours would be given that the publicKey is part of each Url and I'd assume if we are implementing this anyway, we'd want the ads to show for all web puzzles, not just the /goplaynow link.

I am not sure how this will look, but once this code is incorporated I think we should just deploy and see how it looks, I am assuming we can cancel them if they look bad. Also, can someone remind me what the command is to get the web version deployed?  