### PR TITLE
Android deep link fix

### DIFF
--- a/app.json
+++ b/app.json
@@ -83,7 +83,8 @@
           "userTrackingPermission": "This identifier will be used to deliver personalized ads to you."
         }
       ],
-      "sentry-expo"
+      "sentry-expo",
+      "./plugins/withAndroidVerifiedLinksWorkaround"
     ],
     "hooks": {
       "postPublish": [

--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "slug": "pixtery",
     "privacy": "unlisted",
     "sdkVersion": "44.0.0",
-    "version": "2.0.54",
+    "version": "2.0.55",
     "platforms": ["android", "ios"],
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
@@ -28,7 +28,7 @@
     "assetBundlePatterns": ["assets/*"],
     "ios": {
       "bundleIdentifier": "com.fjamstudios.pixtery",
-      "buildNumber": "2.0.54",
+      "buildNumber": "2.0.55",
       "supportsTablet": true,
       "appStoreUrl": "https://apps.apple.com/us/app/pixtery/id1569991739",
       "config": {
@@ -44,7 +44,7 @@
     "android": {
       "package": "com.fjamstudios.pixtery",
       "googleServicesFile": "./google-services.json",
-      "versionCode": 16,
+      "versionCode": 17,
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.fjamstudios.pixtery",
       "adaptiveIcon": {
         "foregroundImage": "./assets/icon.png",

--- a/constants.ts
+++ b/constants.ts
@@ -39,7 +39,7 @@ const PUBLIC_KEY_LENGTH = 9;
 
 const MIN_BOTTOM_CLEARANCE = 0.7;
 
-const VERSION_NUMBER = "2.0.54";
+const VERSION_NUMBER = "2.0.55";
 
 const ARGUABLY_CLEVER_PHRASES = [
   "Please wait!",

--- a/plugins/withAndroidVerifiedLinksWorkaround.js
+++ b/plugins/withAndroidVerifiedLinksWorkaround.js
@@ -1,0 +1,82 @@
+const {
+  createRunOncePlugin,
+  withAndroidManifest,
+} = require("@expo/config-plugins");
+
+/**
+ * @typedef {import('@expo/config-plugins').ConfigPlugin} ConfigPlugin
+ * @typedef {import('@expo/config-plugins').AndroidManifest} AndroidManifest
+ */
+
+/**
+ * Remove the custom Expo dev client scheme from intent filters, which are set to `autoVerify=true`.
+ * The custom scheme `<data android:scheme="exp+<slug>"/>` seems to block verification for these intent filters.
+ * This plugin makes sure there is no scheme in the autoVerify intent filters, that starts with `exp+`.
+ *
+ * @type {ConfigPlugin}
+ */
+const withAndroidVerifiedLinksWorkaround = (config) =>
+  withAndroidManifest(config, (config) => {
+    config.modResults = removeExpoSchemaFromVerifiedIntentFilters(
+      config.modResults
+    );
+    return config;
+  });
+
+/**
+ * Iterate over all `autoVerify=true` intent filters, and pull out schemes starting with `exp+`.
+ *
+ * @param {AndroidManifest} androidManifest
+ */
+function removeExpoSchemaFromVerifiedIntentFilters(androidManifest) {
+  for (const application of androidManifest.manifest.application || []) {
+    for (const activity of application.activity || []) {
+      if (activityHasSingleTaskLaunchMode(activity)) {
+        for (const intentFilter of activity["intent-filter"] || []) {
+          if (
+            intentFilterHasAutoVerification(intentFilter) &&
+            intentFilter?.data
+          ) {
+            intentFilter.data = intentFilterRemoveSchemeFromData(
+              intentFilter,
+              (scheme) => scheme?.startsWith("exp+")
+            );
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  return androidManifest;
+}
+
+/**
+ * Determine if the activity should contain the intent filters to clean.
+ *
+ */
+function activityHasSingleTaskLaunchMode(activity) {
+  return activity?.$?.["android:launchMode"] === "singleTask";
+}
+
+/**
+ * Determine if the intent filter has `autoVerify=true`.
+ */
+function intentFilterHasAutoVerification(intentFilter) {
+  return intentFilter?.$?.["android:autoVerify"] === "true";
+}
+
+/**
+ * Remove schemes from the intent filter that matches the function.
+ */
+function intentFilterRemoveSchemeFromData(intentFilter, schemeMatcher) {
+  return intentFilter?.data?.filter(
+    (entry) => !schemeMatcher(entry?.$["android:scheme"] || "")
+  );
+}
+
+module.exports = createRunOncePlugin(
+  withAndroidVerifiedLinksWorkaround,
+  "withAndroidVerifiedLinksWorkaround",
+  "1.0.0"
+);


### PR DESCRIPTION
This should fix the deep link problem on newer Android versions. Expo docs show how to fix:
[https://docs.expo.dev/guides/deep-linking/#handling-app-links-on-android-with-expo-dev-client](https://docs.expo.dev/guides/deep-linking/#handling-app-links-on-android-with-expo-dev-client)